### PR TITLE
Custom Auth & Role-Based Access Guards ( Issue #15 )

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.7.1",
         "@fortawesome/free-solid-svg-icons": "^6.7.1",
         "angular-auth-oidc-client": "^19.0.0",
+        "jwt-decode": "^4.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -10383,6 +10384,15 @@
         "node >= 0.2.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/karma-source-map-support": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.7.1",
     "@fortawesome/free-solid-svg-icons": "^6.7.1",
     "angular-auth-oidc-client": "^19.0.0",
+    "jwt-decode": "^4.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -16,6 +16,11 @@ export const routes: Routes = [
     loadComponent: () => import('./features/playground').then(c => c.PlaygroundComponent),
   },
   {
+    path: 'candidates',
+    canActivate: [autoLoginPartialRoutesGuard, AuthGuard],
+    loadComponent: () => import('./features/candidates').then(c => c.CandidatesComponent),
+  },
+  {
     path: 'unauthorized',
     canActivate: [],
     loadComponent: () =>
@@ -27,5 +32,5 @@ export const routes: Routes = [
     loadComponent: () => import('./features/error').then(c => c.ErrorComponent),
   },
 
-  { path: '**', redirectTo: 'home' },
+  { path: '**', redirectTo: 'error' },
 ];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { autoLoginPartialRoutesGuard } from 'angular-auth-oidc-client';
 
 import { AuthGuard } from './core/config/auth.guard';
+import { UserRole } from './core/models';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
@@ -13,11 +14,17 @@ export const routes: Routes = [
   {
     path: 'playground',
     canActivate: [autoLoginPartialRoutesGuard, AuthGuard],
+    data: {
+      role: [UserRole.VIEW_PROFILE],
+    },
     loadComponent: () => import('./features/playground').then(c => c.PlaygroundComponent),
   },
   {
     path: 'candidates',
     canActivate: [autoLoginPartialRoutesGuard, AuthGuard],
+    data: {
+      role: [UserRole.VIEW_PROFILE, UserRole.ADMIN],
+    },
     loadComponent: () => import('./features/candidates').then(c => c.CandidatesComponent),
   },
   {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,8 @@
 import { Routes } from '@angular/router';
 import { autoLoginPartialRoutesGuard } from 'angular-auth-oidc-client';
 
+import { AuthGuard } from './core/config/auth.guard';
+
 export const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
 
@@ -10,8 +12,19 @@ export const routes: Routes = [
   },
   {
     path: 'playground',
-    canActivate: [autoLoginPartialRoutesGuard],
+    canActivate: [autoLoginPartialRoutesGuard, AuthGuard],
     loadComponent: () => import('./features/playground').then(c => c.PlaygroundComponent),
+  },
+  {
+    path: 'unauthorized',
+    canActivate: [],
+    loadComponent: () =>
+      import('./features/unauthorized').then(c => c.UnauthorizedComponent),
+  },
+  {
+    path: 'error',
+    canActivate: [],
+    loadComponent: () => import('./features/error').then(c => c.ErrorComponent),
   },
 
   { path: '**', redirectTo: 'home' },

--- a/src/app/core/config/auth.guard.ts
+++ b/src/app/core/config/auth.guard.ts
@@ -1,46 +1,25 @@
 import { inject, Injectable } from '@angular/core';
-import { CanActivate, Router, ActivatedRouteSnapshot  } from '@angular/router';
+import { CanActivate, Router, ActivatedRouteSnapshot } from '@angular/router';
 import { OidcSecurityService } from 'angular-auth-oidc-client';
-import { jwtDecode } from 'jwt-decode';
 
-import { CustomJwtDecoder } from '../models/custom-decode.model';
+import { UserRole } from '../models/role.model';
+
+import { AuthService } from './auth.service';
 
 @Injectable({ providedIn: 'root' })
 export class AuthGuard implements CanActivate {
   private readonly auth = inject(OidcSecurityService);
 
-  private data? = JSON.parse(
-    window.localStorage.getItem('0-poc-frontend-training') || ''
-  );
-  private token = this.data.authnResult.access_token;
-  private tokenData = jwtDecode<CustomJwtDecoder>(this.token);
-  private resourceRoles: unknown;
-  reason = '';
-
-  roles = {
-    playground: {
-      view_profile: 'view-profile',
-    },
-    candidates: {
-      view_profile: 'view-profile',
-      admin: 'administrator',
-    },
-  };
-
   constructor(
-    private authState: OidcSecurityService,
+    private authService: AuthService,
     private router: Router
   ) {}
 
   canActivate(route: ActivatedRouteSnapshot): boolean {
-    const targetPage = route.queryParams['targetPage'] as keyof typeof this.roles;
-    console.log(targetPage);
-
     if (this.auth.isAuthenticated()) {
-      this.checkUserRole(); 
-      const requiredRoles = this.roles[targetPage] ? Object.values(this.roles[targetPage]) : [];
-
-      if (!this.hasAccess(requiredRoles)) {
+      this.authService.checkUserRole();
+      const requiredRoles = route.data['role'] as UserRole[];
+      if (!this.authService.hasAccess(requiredRoles)) {
         this.router.navigate(['/unauthorized']);
         return false;
       }
@@ -49,28 +28,5 @@ export class AuthGuard implements CanActivate {
       this.router.navigate(['/unauthorized']);
       return false;
     }
-  }
-
-  checkUserRole() {
-    if (this.token) {
-      try {
-        this.resourceRoles = this.tokenData.resource_access.account.roles;
-      } catch (error) {
-        console.error('Invalid token:', error);
-        this.router.navigate(['/error']);
-      }
-    }
-  }
-
-  hasAccess(requiredRoles: string[]): boolean {
-    const userRoles = this.resourceRoles as string[];
-    console.log('User roles:', userRoles); // Log user roles to debug
-    console.log('Required roles:', requiredRoles);
-    for(const role of requiredRoles){
-      if(!userRoles.includes(role)){
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/src/app/core/config/auth.guard.ts
+++ b/src/app/core/config/auth.guard.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { CanActivate, Router } from '@angular/router';
+import { CanActivate, Router, ActivatedRouteSnapshot  } from '@angular/router';
 import { OidcSecurityService } from 'angular-auth-oidc-client';
 import { jwtDecode } from 'jwt-decode';
 
@@ -32,11 +32,15 @@ export class AuthGuard implements CanActivate {
     private router: Router
   ) {}
 
-  canActivate(): boolean {
+  canActivate(route: ActivatedRouteSnapshot): boolean {
+    const targetPage = route.queryParams['targetPage'] as keyof typeof this.roles;
+    console.log(targetPage);
+
     if (this.auth.isAuthenticated()) {
-      this.checkUserRole();
-      const requiredRoles = Object.values(this.roles.playground);
-      if (this.hasAccess(requiredRoles)) {
+      this.checkUserRole(); 
+      const requiredRoles = this.roles[targetPage] ? Object.values(this.roles[targetPage]) : [];
+
+      if (!this.hasAccess(requiredRoles)) {
         this.router.navigate(['/unauthorized']);
         return false;
       }
@@ -60,6 +64,13 @@ export class AuthGuard implements CanActivate {
 
   hasAccess(requiredRoles: string[]): boolean {
     const userRoles = this.resourceRoles as string[];
-    return requiredRoles.some(role => userRoles.includes(role));
+    console.log('User roles:', userRoles); // Log user roles to debug
+    console.log('Required roles:', requiredRoles);
+    for(const role of requiredRoles){
+      if(!userRoles.includes(role)){
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/app/core/config/auth.guard.ts
+++ b/src/app/core/config/auth.guard.ts
@@ -17,7 +17,6 @@ export class AuthGuard implements CanActivate {
 
   canActivate(route: ActivatedRouteSnapshot): boolean {
     if (this.auth.isAuthenticated()) {
-      this.authService.checkUserRole();
       const requiredRoles = route.data['role'] as UserRole[];
       if (!this.authService.hasAccess(requiredRoles)) {
         this.router.navigate(['/unauthorized']);

--- a/src/app/core/config/auth.guard.ts
+++ b/src/app/core/config/auth.guard.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { CanActivate, Router, ActivatedRouteSnapshot } from '@angular/router';
 import { OidcSecurityService } from 'angular-auth-oidc-client';
+import { map, Observable } from 'rxjs';
 
 import { UserRole } from '../models/role.model';
 
@@ -15,17 +16,16 @@ export class AuthGuard implements CanActivate {
     private router: Router
   ) {}
 
-  canActivate(route: ActivatedRouteSnapshot): boolean {
-    if (this.auth.isAuthenticated()) {
-      const requiredRoles = route.data['role'] as UserRole[];
-      if (!this.authService.hasAccess(requiredRoles)) {
-        this.router.navigate(['/unauthorized']);
-        return false;
-      }
-      return true;
-    } else {
-      this.router.navigate(['/unauthorized']);
-      return false;
+  canActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
+    return this.auth.getAccessToken().pipe(
+      map(token => {
+        const requiredRoles = route.data['role'] as UserRole[];
+        const hasAccess = token && this.authService.hasAccess(requiredRoles);
+        if (!hasAccess) {
+          this.router.navigate(['/unauthorized']);
+        }
+        return token ? Boolean(this.authService.hasAccess(requiredRoles)) : false;
+      })
+    );
     }
   }
-}

--- a/src/app/core/config/auth.service.ts
+++ b/src/app/core/config/auth.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { jwtDecode } from 'jwt-decode';
+
+import { User, UserRole } from '../models/role.model';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private data? = JSON.parse(
+    window.localStorage.getItem('0-poc-frontend-training') || ''
+  );
+  private token = this.data.authnResult.access_token;
+  private tokenData = jwtDecode<User>(this.token);
+  private resourceRoles: unknown;
+
+  constructor(private router: Router) {}
+
+  checkUserRole() {
+    if (this.token) {
+      try {
+        this.resourceRoles = this.tokenData.resource_access.account.roles;
+      } catch (error) {
+        console.error('Invalid token:', error);
+        this.router.navigate(['/error']);
+      }
+    }
+  }
+
+  hasAccess(requiredRoles: UserRole[]): boolean {
+    const userRoles = this.resourceRoles as UserRole[];
+    for (const role of requiredRoles) {
+      if (!userRoles.includes(role)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/app/core/config/auth.service.ts
+++ b/src/app/core/config/auth.service.ts
@@ -1,38 +1,32 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
+import { OidcSecurityService } from 'angular-auth-oidc-client';
 import { jwtDecode } from 'jwt-decode';
 
 import { User, UserRole } from '../models/role.model';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
-  private data? = JSON.parse(
-    window.localStorage.getItem('0-poc-frontend-training') || ''
-  );
-  private token = this.data.authnResult.access_token;
-  private tokenData = jwtDecode<User>(this.token);
-  private resourceRoles: unknown;
+  private readonly auth = inject(OidcSecurityService);
 
-  constructor(private router: Router) {}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private resourceRoles: any;
 
-  checkUserRole() {
-    if (this.token) {
+  private token = this.auth.getAccessToken().subscribe(token => {
+    if (token) {
       try {
-        this.resourceRoles = this.tokenData.resource_access.account.roles;
+        const tokenData = jwtDecode<User>(token);
+        this.resourceRoles = tokenData.resource_access.account.roles;
       } catch (error) {
         console.error('Invalid token:', error);
         this.router.navigate(['/error']);
       }
     }
-  }
+  });
+
+  constructor(private router: Router) {}
 
   hasAccess(requiredRoles: UserRole[]): boolean {
-    const userRoles = this.resourceRoles as UserRole[];
-    for (const role of requiredRoles) {
-      if (!userRoles.includes(role)) {
-        return false;
-      }
-    }
-    return true;
+    return requiredRoles.every(role => this.resourceRoles.includes(role));
   }
 }

--- a/src/app/core/config/index.ts
+++ b/src/app/core/config/index.ts
@@ -1,2 +1,3 @@
 export * from './auth.config';
 export * from './auth.guard';
+export * from './auth.service';

--- a/src/app/core/config/index.ts
+++ b/src/app/core/config/index.ts
@@ -1,1 +1,2 @@
 export * from './auth.config';
+export * from './auth.guard';

--- a/src/app/core/models/custom-decode.model.ts
+++ b/src/app/core/models/custom-decode.model.ts
@@ -29,9 +29,6 @@ export interface CustomJwtDecoder {
 }
 
 enum UserRole {
-  OFFLINE_ACCESS = 'offline_access',
-  DEFAULT_ROLES_IOT = 'default-roles-iot',
-  UMA_AUTHORIZATION = 'uma_authorization',
   MANAGE_ACCOUNT = 'manage-account',
   MANAGE_ACCOUNT_LINKS = 'manage-account-links',
   VIEW_PROFILE = 'view-profile',

--- a/src/app/core/models/custom-decode.model.ts
+++ b/src/app/core/models/custom-decode.model.ts
@@ -1,0 +1,38 @@
+export interface CustomJwtDecoder {
+  exp: number;
+  iat: number;
+  auth_time: number;
+  jti: string;
+  iss: string;
+  aud: string;
+  sub: string;
+  typ: string;
+  azp: string;
+  sid: string;
+  acr: string;
+  'allowed-origins': string[];
+  realm_access: {
+    roles: UserRole[];
+  };
+  resource_access: {
+    account: {
+      roles: UserRole[];
+    };
+  };
+  scope: string;
+  email_verified: boolean;
+  name: string;
+  preferred_username: string;
+  given_name: string;
+  family_name: string;
+  email: string;
+}
+
+enum UserRole {
+  OFFLINE_ACCESS = 'offline_access',
+  DEFAULT_ROLES_IOT = 'default-roles-iot',
+  UMA_AUTHORIZATION = 'uma_authorization',
+  MANAGE_ACCOUNT = 'manage-account',
+  MANAGE_ACCOUNT_LINKS = 'manage-account-links',
+  VIEW_PROFILE = 'view-profile',
+}

--- a/src/app/core/models/index.ts
+++ b/src/app/core/models/index.ts
@@ -1,3 +1,3 @@
 export * from './company.model';
-export * from './custom-decode.model';
+export * from './role.model';
 export * from './job.model';

--- a/src/app/core/models/index.ts
+++ b/src/app/core/models/index.ts
@@ -1,1 +1,3 @@
 export * from './company.model';
+export * from './custom-decode.model';
+export * from './job.model';

--- a/src/app/core/models/role.model.ts
+++ b/src/app/core/models/role.model.ts
@@ -1,4 +1,11 @@
-export interface CustomJwtDecoder {
+export enum UserRole {
+  MANAGE_ACCOUNT = 'manage-account',
+  MANAGE_ACCOUNT_LINKS = 'manage-account-links',
+  VIEW_PROFILE = 'view-profile',
+  ADMIN = 'administrator',
+}
+
+export interface User {
   exp: number;
   iat: number;
   auth_time: number;
@@ -26,10 +33,4 @@ export interface CustomJwtDecoder {
   given_name: string;
   family_name: string;
   email: string;
-}
-
-enum UserRole {
-  MANAGE_ACCOUNT = 'manage-account',
-  MANAGE_ACCOUNT_LINKS = 'manage-account-links',
-  VIEW_PROFILE = 'view-profile',
 }

--- a/src/app/features/candidates/candidates.component.html
+++ b/src/app/features/candidates/candidates.component.html
@@ -1,0 +1,1 @@
+<p>candidates works!</p>

--- a/src/app/features/candidates/candidates.component.ts
+++ b/src/app/features/candidates/candidates.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'aa-candidates',
+  imports: [],
+  templateUrl: './candidates.component.html',
+})
+export class CandidatesComponent {
+
+}

--- a/src/app/features/candidates/index.ts
+++ b/src/app/features/candidates/index.ts
@@ -1,0 +1,1 @@
+export * from './candidates.component';

--- a/src/app/features/error/error.component.html
+++ b/src/app/features/error/error.component.html
@@ -1,0 +1,8 @@
+<div class="aa--inline-flex aa--items-center">
+  <fa-icon [icon]="faBriefcase" size="2x" class="aa--me-3 aa--text-blue-600" />
+
+  <div class="aa--text-black aa--text-xl aa--font-bold aa--me-5">Job Pilot</div>
+</div>
+<div class="aa--text-red-700 aa--font-bold aa--mt-16">
+  {{ message }}
+</div>

--- a/src/app/features/error/error.component.ts
+++ b/src/app/features/error/error.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faBriefcase } from '@fortawesome/free-solid-svg-icons';
+
+@Component({
+  selector: 'aa-error',
+  imports: [FontAwesomeModule],
+  templateUrl: './error.component.html',
+})
+export class ErrorComponent {
+  faBriefcase = faBriefcase;
+
+  message = 'Oops! Something went wrong. Please try again';
+}

--- a/src/app/features/error/index.ts
+++ b/src/app/features/error/index.ts
@@ -1,0 +1,1 @@
+export * from './error.component';

--- a/src/app/features/unauthorized/index.ts
+++ b/src/app/features/unauthorized/index.ts
@@ -1,0 +1,1 @@
+export * from './unauthorized.component';

--- a/src/app/features/unauthorized/unauthorized.component.html
+++ b/src/app/features/unauthorized/unauthorized.component.html
@@ -1,0 +1,8 @@
+<div class="aa--inline-flex aa--items-center">
+  <fa-icon [icon]="faBriefcase" size="2x" class="aa--me-3 aa--text-blue-600" />
+
+  <div class="aa--text-black aa--text-xl aa--font-bold aa--me-5">Job Pilot</div>
+</div>
+<div class="aa--text-red-700 aa--font-bold aa--mt-16">
+  {{ message }}
+</div>

--- a/src/app/features/unauthorized/unauthorized.component.ts
+++ b/src/app/features/unauthorized/unauthorized.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faBriefcase } from '@fortawesome/free-solid-svg-icons';
+
+@Component({
+  selector: 'aa-unauthorized',
+  imports: [FontAwesomeModule],
+  templateUrl: './unauthorized.component.html',
+})
+export class UnauthorizedComponent {
+  faBriefcase = faBriefcase;
+
+  message = "Access denied! Please contact your system's administrator.";
+}

--- a/src/app/shared/ui/header/navbar/navbar.component.html
+++ b/src/app/shared/ui/header/navbar/navbar.component.html
@@ -4,26 +4,22 @@
     class="aa--justify-left aa--flex aa--grow aa--flex-col aa--gap-5 aa--text-gray-500 md:aa--flex md:aa--flex-row"
     [ngClass]="navClass"
   >
-    <ng-container *ngFor="let item of MenuItems; trackBy: trackByTitle">
+    <ng-container *ngFor="let item of MenuItems; let i =index">
       <div *ngIf="item.active; then content; else other"></div>
       <ng-template #content>
         <li
           class="active hover:aa--text-orange-500 [&.active]:aa--border-b-2 [&.active]:aa--border-blue-700 [&.active]:aa--font-semibold [&.active]:aa--text-blue-700"
         >
-          <a [attr.href]="item.href">
-            <button class="aa--h-full aa--w-auto aa--px-2 aa--py-3">
-              {{ item.title }}
-            </button>
-          </a>
+          <button class="aa--h-full aa--w-auto aa--px-2 aa--py-3">
+            {{ item.title }}
+          </button>
         </li>
       </ng-template>
       <ng-template #other>
         <li class="hover:aa--text-orange-500">
-          <a [attr.href]="item.href">
-            <button class="aa--h-full aa--w-auto aa--px-2 aa--py-3">
-              {{ item.title }}
-            </button>
-          </a>
+          <button class="aa--h-full aa--w-auto aa--px-2 aa--py-3" (click)="onClick(i); $event.preventDefault();">
+            {{ item.title }}
+          </button>
         </li>
       </ng-template>
     </ng-container>

--- a/src/app/shared/ui/header/navbar/navbar.component.ts
+++ b/src/app/shared/ui/header/navbar/navbar.component.ts
@@ -53,14 +53,14 @@ export class NavbarComponent {
     this.handleMenu();
   }
 
-  onClick(index: number){
+  onClick(index: number) {
     for (const item of this.MenuItems) {
-      if(item.active){
-        item.active = !item.active
+      if (item.active) {
+        item.active = !item.active;
       }
     }
     this.MenuItems[index].active = true;
     const targetHref = this.MenuItems[index].href;
-    this.router.navigate([targetHref], { queryParams: { targetPage: targetHref } });
+    this.router.navigate([targetHref]);
   }
 }

--- a/src/app/shared/ui/header/navbar/navbar.component.ts
+++ b/src/app/shared/ui/header/navbar/navbar.component.ts
@@ -1,5 +1,6 @@
 import { NgFor, NgIf, NgClass } from '@angular/common';
 import { Component, HostListener } from '@angular/core';
+import { Router } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faBars, faArrowUp } from '@fortawesome/free-solid-svg-icons';
 
@@ -7,7 +8,6 @@ import { faBars, faArrowUp } from '@fortawesome/free-solid-svg-icons';
   selector: 'aa-navbar',
   imports: [FontAwesomeModule, NgFor, NgIf, NgClass],
   templateUrl: './navbar.component.html',
-  styleUrl: './navbar.component.scss',
 })
 export class NavbarComponent {
   faBars = faBars;
@@ -17,13 +17,15 @@ export class NavbarComponent {
   navClass = 'aa--hidden';
 
   MenuItems = [
-    { title: 'Home', href: '#', active: true },
+    { title: 'Home', href: 'home', active: true },
     { title: 'Find Job', href: '#', active: false },
     { title: 'Employers', href: '#', active: false },
-    { title: 'Candidates', href: '#', active: false },
+    { title: 'Candidates', href: 'candidates', active: false },
     { title: 'Pricing Plans', href: '#', active: false },
-    { title: 'Playground', href: '/playground', active: false },
+    { title: 'Playground', href: 'playground', active: false },
   ];
+
+  constructor(private router: Router) {}
 
   @HostListener('window:resize', ['$event'])
   onResize(event: Event): void {
@@ -49,5 +51,16 @@ export class NavbarComponent {
   toggleMenu(): void {
     this.isMenuOpen = !this.isMenuOpen;
     this.handleMenu();
+  }
+
+  onClick(index: number){
+    for (const item of this.MenuItems) {
+      if(item.active){
+        item.active = !item.active
+      }
+    }
+    this.MenuItems[index].active = true;
+    const targetHref = this.MenuItems[index].href;
+    this.router.navigate([targetHref], { queryParams: { targetPage: targetHref } });
   }
 }


### PR DESCRIPTION
Authentication guards and Role-based access guards implemented. 
A custom decoder model was made to extract the required data from the token and is fully customizable. 

The candidates page and playground page are used to test the role based access. 
For each page's required roles a table was made that uses the navbar's button's href to get the name of the page and use it to check the corresponding value in the role table.

Also 2 new pages were created:  the 'unauthorized' page and an 'error' page to be redirected in "unknown" situations. 