### PR TITLE
23 add notification toast for successerror on company creation

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -29,7 +29,7 @@
                 "input": "public"
               }
             ],
-            "styles": ["src/styles.scss"],
+            "styles": ["src/styles.scss", "node_modules/ngx-toastr/toastr.css"],
             "scripts": []
           },
           "configurations": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.1",
         "angular-auth-oidc-client": "^19.0.0",
         "jwt-decode": "^4.0.0",
+        "ngx-toastr": "^19.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -11474,6 +11475,20 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ngx-toastr": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-19.0.0.tgz",
+      "integrity": "sha512-6pTnktwwWD+kx342wuMOWB4+bkyX9221pAgGz3SHOJH0/MI9erLucS8PeeJDFwbUYyh75nQ6AzVtolgHxi52dQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=16.0.0-0",
+        "@angular/core": ">=16.0.0-0",
+        "@angular/platform-browser": ">=16.0.0-0"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.1",
     "angular-auth-oidc-client": "^19.0.0",
     "jwt-decode": "^4.0.0",
+    "ngx-toastr": "^19.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,5 +1,5 @@
 {
-  "/api/*": {
+  "/api": {
     "target": "https://wapp-training-prod-northeu-001.azurewebsites.net",
     "secure": true,
     "changeOrigin": true,

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -9,6 +9,7 @@ import {
   withAppInitializerAuthCheck,
   authInterceptor,
 } from 'angular-auth-oidc-client';
+import { provideToastr } from 'ngx-toastr';
 
 import { routes } from './app.routes';
 import { oidcConfig } from './core/config';
@@ -25,7 +26,14 @@ export const appConfig: ApplicationConfig = {
       },
       withAppInitializerAuthCheck()
     ),
-
+    provideToastr(
+      {
+        timeOut: 10000,
+        positionClass: 'toast-top-right',
+        preventDuplicates: true,
+        closeButton: true,
+      }
+    ),
     {
       provide: AbstractSecurityStorage,
       useClass: DefaultLocalStorageService,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { autoLoginPartialRoutesGuard } from 'angular-auth-oidc-client';
 
 import { AuthGuard } from './core/config/auth.guard';
 import { UserRole } from './core/models';
+import { CompanyDetailsComponent } from './features/company-details/company-details.component';
 import { styleguideRoutes } from './features/styleguide/styleguide.routes';
 
 export const routes: Routes = [
@@ -26,14 +27,17 @@ export const routes: Routes = [
   },
   {
     path: 'company/create',
-    canActivate: [autoLoginPartialRoutesGuard, AuthGuard],
+    //canActivate: [autoLoginPartialRoutesGuard, AuthGuard],
     data: {
       role: [UserRole.VIEW_PROFILE],
     },
     loadComponent: () =>
       import('./features/company-create').then(c => c.CompanyCreateComponent),
   },
-
+  {
+    path: 'company/:id',
+    component: CompanyDetailsComponent,
+  },
   {
     path: 'unauthorized',
     canActivate: [],

--- a/src/app/core/config/company-api.service.ts
+++ b/src/app/core/config/company-api.service.ts
@@ -29,9 +29,6 @@ export class CompanyApiService {
   }
 
   // Fetch a company by ID
-  // getCompanyById(companyId: string): Observable<CompanyModel> {
-  //   return this.http.get<CompanyModel>(`/api/company/${companyId}`);
-  // }
   getCompanyById(companyId: string): Observable<CompanyModel> {
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
@@ -39,10 +36,9 @@ export class CompanyApiService {
       // 'Authorization': `Bearer ${yourToken}`
     });
 
-    return this.http.get<CompanyModel>(`/api/company/01956bb3-2f74-73c8-b197-feacfc25a9d9`, { headers }).pipe(
+    return this.http.get<CompanyModel>(`/api/company/${companyId}`, { headers }).pipe(
       catchError((error) => {
         console.error('API Error:', error);
-        console.log(companyId);
         return throwError(() => new Error(`Failed to fetch company details: ${error.message}`));
       })
     );

--- a/src/app/core/config/company-api.service.ts
+++ b/src/app/core/config/company-api.service.ts
@@ -1,6 +1,6 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { catchError, Observable, throwError } from 'rxjs';
 
 import { CompanyModel } from '../models/company.model';
 
@@ -26,5 +26,25 @@ export class CompanyApiService {
     return this.http.post<CompanyModel>('/api/company', newCompany, {
       headers: { 'Content-Type': 'application/json' },
     });
+  }
+
+  // Fetch a company by ID
+  // getCompanyById(companyId: string): Observable<CompanyModel> {
+  //   return this.http.get<CompanyModel>(`/api/company/${companyId}`);
+  // }
+  getCompanyById(companyId: string): Observable<CompanyModel> {
+    const headers = new HttpHeaders({
+      'Content-Type': 'application/json',
+      // Add authentication headers if needed (e.g., Authorization)
+      // 'Authorization': `Bearer ${yourToken}`
+    });
+
+    return this.http.get<CompanyModel>(`/api/company/01956bb3-2f74-73c8-b197-feacfc25a9d9`, { headers }).pipe(
+      catchError((error) => {
+        console.error('API Error:', error);
+        console.log(companyId);
+        return throwError(() => new Error(`Failed to fetch company details: ${error.message}`));
+      })
+    );
   }
 }

--- a/src/app/core/models/company.model.ts
+++ b/src/app/core/models/company.model.ts
@@ -1,4 +1,5 @@
 export interface CompanyModel {
+  id: string;
   name: string;
   website: string;
   vat: string;

--- a/src/app/features/company-create/company-create.component.html
+++ b/src/app/features/company-create/company-create.component.html
@@ -193,7 +193,7 @@
     <button
       type="submit"
       [disabled]="newCompany.invalid"
-      class="aa--justify-self-center hover:aa--bg-gray-200 aa--border aa--rounded aa--w-lg aa--py-2 aa--px-3 aa--text-gray-700 aa--leading-tight focus:aa--outline-none focus:aa--shadow-outline"
+      class="aa--justify-self-center hover:aa--bg-gray-200 aa--border aa--rounded aa--w-lg aa--py-2 aa--px-3 aa--text-gray-700 aa--leading-tight focus:aa--outline-none focus:aa--shadow-outline aa--cursor-pointer"
     >
       Submit
     </button>

--- a/src/app/features/company-create/company-create.component.html
+++ b/src/app/features/company-create/company-create.component.html
@@ -1,5 +1,5 @@
 <div
-  class="aa--rounded aa--text-start aa--px-8 aa--pt-6 aa--pb-8 aa--mb-4 aa--bg-gray-100 aa--w-full aa--max-w-2xl aa--text-center aa--border aa--rounded aa--border-gray-200 aa--flex-column"
+  class="aa--text-start aa--px-8 aa--pt-6 aa--pb-8 aa--mb-4 aa--bg-gray-100 aa--w-full aa--max-w-2xl aa--border aa--rounded aa--border-gray-200 aa--flex-column"
 >
   <div
     class="aa--text-black aa--text-2xl aa--align-text-top aa--font-bold aa--origin-center"

--- a/src/app/features/company-create/company-create.component.ts
+++ b/src/app/features/company-create/company-create.component.ts
@@ -1,10 +1,12 @@
 import { CommonModule, NgIf } from '@angular/common';
 import { Component, inject, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { ToastrService } from 'ngx-toastr';
 
 import { CompanyApiService } from '../../core/config/company-api.service';
-import { CompanyModel } from '../../core/models/company.model';
 
+import { CompanyModel } from './../../core/models/company.model';
 @Component({
   selector: 'aa-company-create',
   imports: [ReactiveFormsModule, CommonModule, NgIf],
@@ -13,6 +15,9 @@ import { CompanyModel } from '../../core/models/company.model';
 export class CompanyCreateComponent implements OnInit {
   private fb = inject(FormBuilder);
   private companyApi = inject(CompanyApiService);
+  private toastr = inject(ToastrService);
+
+  private router = inject(Router);
 
   company!: CompanyModel;
   newCompany!: FormGroup;
@@ -23,22 +28,24 @@ export class CompanyCreateComponent implements OnInit {
 
   onSubmit() {
     if (this.newCompany.invalid) {
-      alert('Some fields are not correct! Please check again.');
+      this.toastr.warning('Some fields are not correct! Please check again.', 'Validation Error');
       return;
     }
     this.company = this.newCompany.value as CompanyModel;
     console.log('Form Submitted', this.company);
     this.companyApi.createCompany(this.company).subscribe({
       next: response => {
-        alert(`Company "${this.company.name}" created successfully!`);
+        this.toastr.success(`Company "${this.company.name}" created successfully!`, 'Success');
         console.log('Company created successfully:', response);
+        // Redirect to the company details page after successful submission
+      this.router.navigate([`/company/${response.id}`]);
+        this.newCompany.reset(); // Reset form only after successful submission
       },
       error: error => {
         console.error('Error creating company:', error);
-        alert('Failed to create company. Please try again.');
+        this.toastr.error('Failed to create company. Please try again.', 'Error');
       },
     });
-    this.newCompany.reset();
   }
 
   isFieldInvalid(field: string) {

--- a/src/app/features/company-details/company-details.component.html
+++ b/src/app/features/company-details/company-details.component.html
@@ -1,28 +1,50 @@
-<div *ngIf="company; else loading">
-  <h2>{{ company.name }}</h2>
-  <p>
-    <strong>Website:</strong>
-    <a [href]="company.website">{{ company.website }}</a>
-  </p>
-  <p>
-    <strong>VAT:</strong>
-    {{ company.vat }}
-  </p>
-  <p>
-    <strong>Phone Number:</strong>
-    {{ company.phoneNumber }}
-  </p>
-  <p>
-    <strong>Address:</strong>
-    {{ company.address.street }}, {{ company.address.city }},
-    {{ company.address.country }}
-  </p>
+<div
+  *ngIf="company; else loading"
+  class="aa--text-start aa--px-8 aa--pt-6 aa--pb-8 aa--mb-4 aa--bg-gray-100 aa--w-full aa--max-w-2xl aa--border aa--rounded aa--border-gray-200"
+>
+  <h2 class="aa--text-black aa--text-2xl aa--font-bold aa--mb-4">{{ company.name }}</h2>
 
-  <button>Edit</button>
-  <button>Delete</button>
+  <div class="aa--mb-4">
+    <strong class="aa--text-gray-700">Website:</strong>
+    <a [href]="company.website" class="aa--text-blue-500 hover:aa--underline">
+      {{ company.website }}
+    </a>
+  </div>
+
+  <div class="aa--mb-4">
+    <strong class="aa--text-gray-700">VAT:&nbsp;</strong>
+    <span class="aa--text-gray-900">{{ company.vat }}</span>
+  </div>
+
+  <div class="aa--mb-4">
+    <strong class="aa--text-gray-700">Phone Number:&nbsp;</strong>
+    <span class="aa--text-gray-900">{{ company.phoneNumber }}</span>
+  </div>
+
+  <div class="aa--mb-4">
+    <strong class="aa--text-gray-700">Address:</strong>
+    <span class="aa--text-gray-900">
+      {{ company.address.street }} {{ company.address.streetNumber }},
+      {{ company.address.city }},
+      {{ company.address.country }}
+    </span>
+  </div>
+
+  <div class="aa--flex aa--gap-4">
+    <button
+      class="aa--bg-blue-500 aa--text-white aa--py-2 aa--px-4 aa--rounded hover:aa--bg-blue-600"
+    >
+      Edit
+    </button>
+    <button
+      class="aa--bg-red-500 aa--text-white aa--py-2 aa--px-4 aa--rounded hover:aa--bg-red-600"
+    >
+      Delete
+    </button>
+  </div>
 </div>
 
 <!-- Loading placeholder -->
 <ng-template #loading>
-  <p>Loading company details...</p>
+  <p class="aa--text-gray-700">Loading company details...</p>
 </ng-template>

--- a/src/app/features/company-details/company-details.component.html
+++ b/src/app/features/company-details/company-details.component.html
@@ -1,0 +1,28 @@
+<div *ngIf="company; else loading">
+  <h2>{{ company.name }}</h2>
+  <p>
+    <strong>Website:</strong>
+    <a [href]="company.website">{{ company.website }}</a>
+  </p>
+  <p>
+    <strong>VAT:</strong>
+    {{ company.vat }}
+  </p>
+  <p>
+    <strong>Phone Number:</strong>
+    {{ company.phoneNumber }}
+  </p>
+  <p>
+    <strong>Address:</strong>
+    {{ company.address.street }}, {{ company.address.city }},
+    {{ company.address.country }}
+  </p>
+
+  <button>Edit</button>
+  <button>Delete</button>
+</div>
+
+<!-- Loading placeholder -->
+<ng-template #loading>
+  <p>Loading company details...</p>
+</ng-template>

--- a/src/app/features/company-details/company-details.component.ts
+++ b/src/app/features/company-details/company-details.component.ts
@@ -1,0 +1,37 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+import { CompanyApiService } from '../../core/config/company-api.service';
+import { CompanyModel } from '../../core/models/company.model';
+
+@Component({
+  selector: 'aa-company-details',
+  imports: [CommonModule],
+  templateUrl: './company-details.component.html',
+})
+export class CompanyDetailsComponent implements OnInit {
+  company!: CompanyModel;
+  companyId!: string;
+
+  constructor(
+    private route: ActivatedRoute,
+    private companyApi: CompanyApiService
+  ) {}
+
+  ngOnInit(): void {
+    this.companyId = this.route.snapshot.paramMap.get('id')!;
+    this.fetchCompanyDetails(this.companyId);
+  }
+
+  fetchCompanyDetails(companyId: string) {
+    this.companyApi.getCompanyById(companyId).subscribe({
+      next: (company) => {
+        this.company = company;
+      },
+      error: (error) => {
+        console.error('Error fetching company details:', error);
+      },
+    });
+  }
+}

--- a/src/app/features/playground/playground.component.html
+++ b/src/app/features/playground/playground.component.html
@@ -19,8 +19,8 @@
     }"
   />
   <div class="aa--flex aa--flex-wrap aa--gap-5">
-    <aa-company-card [companyData]="company1" />
+    <!-- <aa-company-card [companyData]="company1" />
     <aa-company-card [companyData]="company2" />
-    <aa-company-card [companyData]="company3" />
+    <aa-company-card [companyData]="company3" /> -->
   </div>
 </div>

--- a/src/app/features/playground/playground.component.html
+++ b/src/app/features/playground/playground.component.html
@@ -19,8 +19,8 @@
     }"
   />
   <div class="aa--flex aa--flex-wrap aa--gap-5">
-    <!-- <aa-company-card [companyData]="company1" />
+    <aa-company-card [companyData]="company1" />
     <aa-company-card [companyData]="company2" />
-    <aa-company-card [companyData]="company3" /> -->
+    <aa-company-card [companyData]="company3" />
   </div>
 </div>

--- a/src/app/features/playground/playground.component.ts
+++ b/src/app/features/playground/playground.component.ts
@@ -2,14 +2,14 @@ import { AsyncPipe, JsonPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { OidcSecurityService } from 'angular-auth-oidc-client';
 
-import { CompanyModel } from '../../core/models';
-import { CompanyCardComponent } from '../../shared/ui/cards/company-card';
+//import { CompanyModel } from '../../core/models';
+//import { CompanyCardComponent } from '../../shared/ui/cards/company-card';
 import { JobCardComponent } from '../../shared/ui/cards/job-card';
 
 @Component({
   selector: 'aa-playground',
   standalone: true,
-  imports: [JobCardComponent, CompanyCardComponent, AsyncPipe, JsonPipe],
+  imports: [JobCardComponent, AsyncPipe, JsonPipe],
   templateUrl: './playground.component.html',
 })
 export class PlaygroundComponent {
@@ -18,57 +18,57 @@ export class PlaygroundComponent {
   userData$ = this.auth.userData$;
   isAuthenticated$ = this.auth.isAuthenticated$;
 
-  company1: CompanyModel = {
-    name: 'Acme Inc.',
-    website: 'site.com',
-    vat: '1512512516',
-    address: {
-      country: 'U.S.A.',
-      city: 'San Francisco',
-      street: 'Street',
-      streetNumber: '69',
-      postalCode: '42069',
-    },
-    isSponsored: true,
-    phoneNumber: '1234567890',
-    openPositions: 5,
-    openPositionsUrl: '#',
-    logoUrl: 'logo.jpg',
-  };
+  // company1: CompanyModel = {
+  //   name: 'Acme Inc.',
+  //   website: 'site.com',
+  //   vat: '1512512516',
+  //   address: {
+  //     country: 'U.S.A.',
+  //     city: 'San Francisco',
+  //     street: 'Street',
+  //     streetNumber: '69',
+  //     postalCode: '42069',
+  //   },
+  //   isSponsored: true,
+  //   phoneNumber: '1234567890',
+  //   openPositions: 5,
+  //   openPositionsUrl: '#',
+  //   logoUrl: 'logo.jpg',
+  // };
 
-  company2: CompanyModel = {
-    name: 'Vasko Co',
-    website: 'site.com',
-    vat: '1512512516',
-    address: {
-      country: 'Greece',
-      city: 'Argyroupoli',
-      street: 'Street',
-      streetNumber: '69',
-      postalCode: '42069',
-    },
-    isSponsored: true,
-    phoneNumber: '1234567890',
-    openPositions: 5,
-    openPositionsUrl: '#',
-    logoUrl: 'logo.jpg',
-  };
+  // company2: CompanyModel = {
+  //   name: 'Vasko Co',
+  //   website: 'site.com',
+  //   vat: '1512512516',
+  //   address: {
+  //     country: 'Greece',
+  //     city: 'Argyroupoli',
+  //     street: 'Street',
+  //     streetNumber: '69',
+  //     postalCode: '42069',
+  //   },
+  //   isSponsored: true,
+  //   phoneNumber: '1234567890',
+  //   openPositions: 5,
+  //   openPositionsUrl: '#',
+  //   logoUrl: 'logo.jpg',
+  // };
 
-  company3: CompanyModel = {
-    name: 'Genera Co',
-    website: 'site.com',
-    vat: '1512512516',
-    address: {
-      country: 'Greece',
-      city: 'Athens',
-      street: 'Street',
-      streetNumber: '69',
-      postalCode: '42069',
-    },
-    isSponsored: false,
-    phoneNumber: '1234567890',
-    openPositions: 5,
-    openPositionsUrl: '#',
-    logoUrl: 'logo.jpg',
-  };
+  // company3: CompanyModel = {
+  //   name: 'Genera Co',
+  //   website: 'site.com',
+  //   vat: '1512512516',
+  //   address: {
+  //     country: 'Greece',
+  //     city: 'Athens',
+  //     street: 'Street',
+  //     streetNumber: '69',
+  //     postalCode: '42069',
+  //   },
+  //   isSponsored: false,
+  //   phoneNumber: '1234567890',
+  //   openPositions: 5,
+  //   openPositionsUrl: '#',
+  //   logoUrl: 'logo.jpg',
+  // };
 }

--- a/src/app/features/playground/playground.component.ts
+++ b/src/app/features/playground/playground.component.ts
@@ -2,14 +2,14 @@ import { AsyncPipe, JsonPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { OidcSecurityService } from 'angular-auth-oidc-client';
 
-//import { CompanyModel } from '../../core/models';
-//import { CompanyCardComponent } from '../../shared/ui/cards/company-card';
+import { CompanyModel } from '../../core/models';
+import { CompanyCardComponent } from '../../shared/ui/cards/company-card';
 import { JobCardComponent } from '../../shared/ui/cards/job-card';
 
 @Component({
   selector: 'aa-playground',
   standalone: true,
-  imports: [JobCardComponent, AsyncPipe, JsonPipe],
+  imports: [JobCardComponent, AsyncPipe, JsonPipe, CompanyCardComponent],
   templateUrl: './playground.component.html',
 })
 export class PlaygroundComponent {
@@ -18,57 +18,60 @@ export class PlaygroundComponent {
   userData$ = this.auth.userData$;
   isAuthenticated$ = this.auth.isAuthenticated$;
 
-  // company1: CompanyModel = {
-  //   name: 'Acme Inc.',
-  //   website: 'site.com',
-  //   vat: '1512512516',
-  //   address: {
-  //     country: 'U.S.A.',
-  //     city: 'San Francisco',
-  //     street: 'Street',
-  //     streetNumber: '69',
-  //     postalCode: '42069',
-  //   },
-  //   isSponsored: true,
-  //   phoneNumber: '1234567890',
-  //   openPositions: 5,
-  //   openPositionsUrl: '#',
-  //   logoUrl: 'logo.jpg',
-  // };
+  company1: CompanyModel = {
+    id: '12345',
+    name: 'Acme Inc.',
+    website: 'site.com',
+    vat: '1512512516',
+    address: {
+      country: 'U.S.A.',
+      city: 'San Francisco',
+      street: 'Street',
+      streetNumber: '69',
+      postalCode: '42069',
+    },
+    isSponsored: true,
+    phoneNumber: '1234567890',
+    openPositions: 5,
+    openPositionsUrl: '#',
+    logoUrl: 'logo.jpg',
+  };
 
-  // company2: CompanyModel = {
-  //   name: 'Vasko Co',
-  //   website: 'site.com',
-  //   vat: '1512512516',
-  //   address: {
-  //     country: 'Greece',
-  //     city: 'Argyroupoli',
-  //     street: 'Street',
-  //     streetNumber: '69',
-  //     postalCode: '42069',
-  //   },
-  //   isSponsored: true,
-  //   phoneNumber: '1234567890',
-  //   openPositions: 5,
-  //   openPositionsUrl: '#',
-  //   logoUrl: 'logo.jpg',
-  // };
+  company2: CompanyModel = {
+    id: '452136',
+    name: 'Vasko Co',
+    website: 'site.com',
+    vat: '1512512516',
+    address: {
+      country: 'Greece',
+      city: 'Argyroupoli',
+      street: 'Street',
+      streetNumber: '69',
+      postalCode: '42069',
+    },
+    isSponsored: true,
+    phoneNumber: '1234567890',
+    openPositions: 5,
+    openPositionsUrl: '#',
+    logoUrl: 'logo.jpg',
+  };
 
-  // company3: CompanyModel = {
-  //   name: 'Genera Co',
-  //   website: 'site.com',
-  //   vat: '1512512516',
-  //   address: {
-  //     country: 'Greece',
-  //     city: 'Athens',
-  //     street: 'Street',
-  //     streetNumber: '69',
-  //     postalCode: '42069',
-  //   },
-  //   isSponsored: false,
-  //   phoneNumber: '1234567890',
-  //   openPositions: 5,
-  //   openPositionsUrl: '#',
-  //   logoUrl: 'logo.jpg',
-  // };
+  company3: CompanyModel = {
+    id: '2369874',
+    name: 'Genera Co',
+    website: 'site.com',
+    vat: '1512512516',
+    address: {
+      country: 'Greece',
+      city: 'Athens',
+      street: 'Street',
+      streetNumber: '69',
+      postalCode: '42069',
+    },
+    isSponsored: false,
+    phoneNumber: '1234567890',
+    openPositions: 5,
+    openPositionsUrl: '#',
+    logoUrl: 'logo.jpg',
+  };
 }

--- a/src/app/features/styleguide/company-cards/company-cards.component.ts
+++ b/src/app/features/styleguide/company-cards/company-cards.component.ts
@@ -11,40 +11,40 @@ import { CompanyCardComponent } from '../../../shared/ui/cards/company-card';
 })
 export class CompanyCardsComponent {
   cards: CompanyModel[] = [
-    {
-      name: 'Tech Corp',
-      website: 'https://techcorp.com',
-      vat: 'GR123456789',
-      logoUrl: 'https://via.placeholder.com/100',
-      address: {
-        country: 'Greece',
-        city: 'Athens',
-        street: 'Tech Street',
-        streetNumber: '10',
-        postalCode: '10010',
-      },
-      isSponsored: true,
-      phoneNumber: '+30 210 1234567',
-      openPositions: 5,
-      openPositionsUrl: 'https://techcorp.com/careers',
-    },
-    {
-      name: 'Code Solutions',
-      website: 'https://codesolutions.com',
-      vat: 'GR987654321',
-      logoUrl: 'https://via.placeholder.com/100',
-      address: {
-        country: 'Greece',
-        city: 'Thessaloniki',
-        street: 'Code Avenue',
-        streetNumber: '25',
-        postalCode: '54625',
-      },
-      isSponsored: false,
-      phoneNumber: '+30 2310 765432',
-      openPositions: 3,
-      openPositionsUrl: 'https://codesolutions.com/jobs',
-    },
+    // {
+    //   name: 'Tech Corp',
+    //   website: 'https://techcorp.com',
+    //   vat: 'GR123456789',
+    //   logoUrl: 'https://via.placeholder.com/100',
+    //   address: {
+    //     country: 'Greece',
+    //     city: 'Athens',
+    //     street: 'Tech Street',
+    //     streetNumber: '10',
+    //     postalCode: '10010',
+    //   },
+    //   isSponsored: true,
+    //   phoneNumber: '+30 210 1234567',
+    //   openPositions: 5,
+    //   openPositionsUrl: 'https://techcorp.com/careers',
+    // },
+    // {
+    //   name: 'Code Solutions',
+    //   website: 'https://codesolutions.com',
+    //   vat: 'GR987654321',
+    //   logoUrl: 'https://via.placeholder.com/100',
+    //   address: {
+    //     country: 'Greece',
+    //     city: 'Thessaloniki',
+    //     street: 'Code Avenue',
+    //     streetNumber: '25',
+    //     postalCode: '54625',
+    //   },
+    //   isSponsored: false,
+    //   phoneNumber: '+30 2310 765432',
+    //   openPositions: 3,
+    //   openPositionsUrl: 'https://codesolutions.com/jobs',
+    // },
   ];
 
   trackByCompany(index: number, company: CompanyModel): string {

--- a/src/app/features/styleguide/company-cards/company-cards.component.ts
+++ b/src/app/features/styleguide/company-cards/company-cards.component.ts
@@ -11,40 +11,42 @@ import { CompanyCardComponent } from '../../../shared/ui/cards/company-card';
 })
 export class CompanyCardsComponent {
   cards: CompanyModel[] = [
-    // {
-    //   name: 'Tech Corp',
-    //   website: 'https://techcorp.com',
-    //   vat: 'GR123456789',
-    //   logoUrl: 'https://via.placeholder.com/100',
-    //   address: {
-    //     country: 'Greece',
-    //     city: 'Athens',
-    //     street: 'Tech Street',
-    //     streetNumber: '10',
-    //     postalCode: '10010',
-    //   },
-    //   isSponsored: true,
-    //   phoneNumber: '+30 210 1234567',
-    //   openPositions: 5,
-    //   openPositionsUrl: 'https://techcorp.com/careers',
-    // },
-    // {
-    //   name: 'Code Solutions',
-    //   website: 'https://codesolutions.com',
-    //   vat: 'GR987654321',
-    //   logoUrl: 'https://via.placeholder.com/100',
-    //   address: {
-    //     country: 'Greece',
-    //     city: 'Thessaloniki',
-    //     street: 'Code Avenue',
-    //     streetNumber: '25',
-    //     postalCode: '54625',
-    //   },
-    //   isSponsored: false,
-    //   phoneNumber: '+30 2310 765432',
-    //   openPositions: 3,
-    //   openPositionsUrl: 'https://codesolutions.com/jobs',
-    // },
+    {
+      id: 'unknown',
+      name: 'Tech Corp',
+      website: 'https://techcorp.com',
+      vat: 'GR123456789',
+      logoUrl: 'https://via.placeholder.com/100',
+      address: {
+        country: 'Greece',
+        city: 'Athens',
+        street: 'Tech Street',
+        streetNumber: '10',
+        postalCode: '10010',
+      },
+      isSponsored: true,
+      phoneNumber: '+30 210 1234567',
+      openPositions: 5,
+      openPositionsUrl: 'https://techcorp.com/careers',
+    },
+    {
+      id: 'unknown2',
+      name: 'Code Solutions',
+      website: 'https://codesolutions.com',
+      vat: 'GR987654321',
+      logoUrl: 'https://via.placeholder.com/100',
+      address: {
+        country: 'Greece',
+        city: 'Thessaloniki',
+        street: 'Code Avenue',
+        streetNumber: '25',
+        postalCode: '54625',
+      },
+      isSponsored: false,
+      phoneNumber: '+30 2310 765432',
+      openPositions: 3,
+      openPositionsUrl: 'https://codesolutions.com/jobs',
+    },
   ];
 
   trackByCompany(index: number, company: CompanyModel): string {


### PR DESCRIPTION
Toast notifications are displayed for both success and error cases.
The user is redirected to /company/{id} after a successful submission.
A new route /company/{id} is available to display company details.
The company detail page includes Edit and Delete placeholder buttons.
You can use this id: 01956bb3-2f74-73c8-b197-feacfc25a9d9 (currently working)